### PR TITLE
Add cohort mode, Winnowmap support, and model-specific VCF merge handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ dviont call \
     -r ./data/test.gb \
     -i ./data/reads.fastq.gz \
     -t 4 \
+    -p ./model/r1041_e82_400bps_sup_v500 \
     -m r1041_e82_400bps_sup_v500 \
     -s SAMPLE1 \
     --preset ont-q20


### PR DESCRIPTION
- Added cohort mode for running DviONT across multiple samples.
- Added winnowmap.py to support Winnowmap as an alternative read aligner.
- Updated the README with the new workflow and usage information.
- Removed -O 20,60 from the Minimap2 parameters in minimap.py.
- Updated Clair3 final VCF handling: The default v430 model now uses Clair3's own merged output as the final VCF. Other Clair3 models continue to use the previous merge_vcf.py merging logic.